### PR TITLE
Add .yarnrc to ignore engine checks during install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true


### PR DESCRIPTION
Prevents nock@14 engine check failure on Node 16 when the prepare script triggers an inner yarn install for git URL dependencies.